### PR TITLE
Mise à jour des critères d'éligibilité à la vaccination

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,14 +82,12 @@
                     De nombreuses personnes sont éligibles à la vaccination contre la Covid-19. On peut être éligible à la vaccination selon son âge, sa santé, ou sa profession. Voici la liste des personnes qui peuvent dès à présent être vaccinées&nbsp;:
                 </p>
                 <ul>
-                   <li>les personnes de 70 ans et plus quel que soit leur lieu de résidence&nbsp;;</li>
-                    <li>les résidents en établissements d’hébergement pour personnes âgées dépendantes (Ehpad), en unités de soins de longue durée (USLD) ou hébergées en résidences autonomie et résidences services&nbsp;;</li>
-                    <li>Les adultes qui souffrent d’une pathologie considérée comme à très haut risque de développer une forme grave de la Covid-19&nbsp;;</li>
-                    <li>les personnes (sans critère d’âge) en situation de handicap hébergées en maisons d’accueil spécialisées (MAS) ou en foyers d’accueil médicalisés (FAM)&nbsp;;</li>
-                    <li>les femmes enceintes à partir du deuxième trimestre de la grossesse&nbsp;;</li>
-                    <li>les personnes de 50 à 69 ans inclus souffrant d’au moins une comorbidité&nbsp;;</li>
-                    <li>les résidents de 60 ans et plus dans les foyers de travailleurs migrants (FTM)&nbsp;;</li>
-                    <li>toutes les personnes de 55 à 74 ans avec les vaccins AstraZeneca et Janssen à partir depuis le lundi 12 avril.</li>
+                    <li>personnes de 55 ans et plus quel que soit leur lieu de vie et leur état de santé (avec ou sans comorbidités)&nbsp;;</li>
+                    <li>personnes de 50 à 55 ans inclus souffrant d’une pathologie à très haut risque de forme grave de Covid-19 ou d'une ou plusieurs comorbidités&nbsp;;</li>
+                    <li>personnes de 18 à 49 ans inclus souffrant d’une pathologie à très haut risque de forme grave de Covid-19&nbsp;;</li>
+                    <li>personnes majeures en situation de handicap, hébergées en maison d’accueil spécialisée ou foyer d’accueil médicalisé&nbsp;;</li>
+                    <li>adultes vivant dans le même foyer qu’une personne sévèrement immunodéprimée, enfant ou adulte (transplantés d’organes solides, transplantés récents de moelle osseuse récents, patients dialysés, patients atteints de maladies auto-immunes sous traitement immunosuppresseur fort de type anti-CD20 ou anti-métabolites).</li>
+                    <li>femmes enceintes à partir du 2e trimestre de grossesse.</li>
                 </ul>
                 <p>Les professionnels de santé et du secteur médico-social sont également éligibles à la vaccination contre la Covid-19.</p>
 


### PR DESCRIPTION
Les critères d'éligibilité ne sont plus à jour (il est indiqué que toutes les personnes de 70 ans et plus sont éligibles au lieu de 55 ans aujourd'hui ).

Cette modification  propose de remplacer ces critères par la liste recopiée depuis https://www.gouvernement.fr/info-coronavirus/vaccins (ordre modifié pour indiquer le cas général en première position).
La formulation est différente, et peut-être à adapter.

La PR https://github.com/CovidTrackerFr/vitemadose-front/pull/109 porte sur l'ajout d'un lien vers un site du gouvernement pour informations sur l'éligibilité, mais la discussion en commentaire évoque une simplification de la mise à jour des critères sur vitemadose.
Il me parait important que les critères soient à jour, en attendant une avancée sur le sujet.